### PR TITLE
Fix React Native 0.83+ compatibility

### DIFF
--- a/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
+++ b/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
@@ -412,7 +412,7 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
                 val randomId = randomId()
 
                 var resolvedIndex: Any = "new"
-                when (val type = addressIndex.getType()) {
+                when (val type = addressIndex.type) {
                     ReadableType.String -> {
                         resolvedIndex = (addressIndex as Dynamic).asString() ?: "new"
                     }
@@ -445,7 +445,7 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
             try {
                 val randomId = randomId()
                 var resolvedIndex: Any = "new"
-                when (val type = addressIndex.getType()) {
+                when (val type = addressIndex.type) {
                     ReadableType.String -> {
                         resolvedIndex = (addressIndex as Dynamic).asString() ?: "new"
                     }

--- a/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
+++ b/android/src/main/java/io/ltbl/bdkrn/BdkRnModule.kt
@@ -687,7 +687,7 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
         Thread {
             val mappedOutPoints: MutableList<OutPoint> = mutableListOf()
             for (i in 0 until outPoints.size())
-                mappedOutPoints.add(createOutPoint(outPoints.getMap(i)))
+                mappedOutPoints.add(createOutPoint(outPoints.getMap(i)!!))
             _txBuilders[id] = _txBuilders[id]!!.addUtxos(mappedOutPoints)
             result.resolve(true)
         }.start()
@@ -726,7 +726,7 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
         Thread {
             val mappedOutPoints: MutableList<OutPoint> = mutableListOf()
             for (i in 0 until outPoints.size())
-                mappedOutPoints.add(createOutPoint(outPoints.getMap(i)))
+                mappedOutPoints.add(createOutPoint(outPoints.getMap(i)!!))
             _txBuilders[id] = _txBuilders[id]!!.unspendable(mappedOutPoints)
             result.resolve(true)
         }.start()
@@ -803,9 +803,9 @@ class BdkRnModule(reactContext: ReactApplicationContext) :
         Thread {
             var scriptAmounts: MutableList<ScriptAmount> = mutableListOf()
             for (i in 0 until recipients.size()) {
-                val item = recipients.getMap(i)
-                val amount = item.getInt("amount").toULong()
-                val scriptId = item.getMap("script")!!.getString("id")
+                val item = recipients.getMap(i)!!
+                val amount = item!!.getInt("amount").toULong()
+                val scriptId = item!!.getMap("script")!!.getString("id")
                 val scriptAmount = ScriptAmount(_scripts[scriptId]!!, amount)
                 scriptAmounts.add(scriptAmount)
             }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "scripts": {
     "compile": "rm -rf lib && tsc -p .",
     "lint": "eslint . --ext .js,.ts --fix",
-    "prepare": "yarn compile",
     "test": "jest",
     "test:ci": "jest --ci",
     "postinstall": "node ./src/installer.js"


### PR DESCRIPTION
## Summary

Fixes Kotlin compilation errors when building with React Native 0.83+ (Gradle 9.0):

- Replace `Dynamic.getType()` with `.type` property access (method was removed in RN 0.83)
- Add non-null assertions for `ReadableArray.getMap()` which now returns `ReadableMap?` instead of `ReadableMap`
- Remove `prepare` script that runs `yarn compile` (fails when installed via `github:` reference)

## Context

Same fix as [LtbLightning/bdk-rn#87](https://github.com/LtbLightning/bdk-rn/pull/87) submitted to the upstream repo, but that PR doesn't appear to be getting reviewed — the upstream repo hasn't merged anything since Jan 2024.

These changes are backwards-compatible with older RN versions — `.type` was always available as a property, and `!!` assertions are harmless on non-nullable types.

## Testing

- Kotlin compilation succeeds on RN 0.83.4 / Gradle 9.0
- Tested in [Lightning Piggy](https://github.com/BenGWeeks/lightning-piggy-mobile) React Native app

🤖 Generated with [Claude Code](https://claude.com/claude-code)